### PR TITLE
chore: fix patch error check

### DIFF
--- a/src/metav/release.clj
+++ b/src/metav/release.clj
@@ -44,9 +44,9 @@
         (apply git/add! working-dir rendered)))
     (when (or spit template)
       (git/commit! working-dir (str "Bump to version " next-version " and spit/render related metadata in file(s).")))
-    (let [tag-result (apply git/tag! repo-dir tag (json/write-str (metadata-as-edn invocation-context next-version)) (when without-sign [:sign false]))]
-      (if (int? (first tag-result));;error exit code if so return stderr
-        (throw (Exception. (str "Error with git tag command:" (get tag-result 2))))))
+    (let [{:keys [exit out err]} (apply git/tag! repo-dir tag (json/write-str (metadata-as-edn invocation-context next-version)) (when without-sign [:sign false]))]
+      (if (not (zero? exit));;error exit code if so return stderr
+        (throw (Exception. (str "Error with git tag command:" err)))))
     (if without-push
       [module-name next-version tag]
       (let [push-result (git/push! repo-dir)]


### PR DESCRIPTION
return value of `git/tag!` in release was not being used correctly and would not fail on tag fails